### PR TITLE
Add missing .alert-dismissible class to flash

### DIFF
--- a/app/views/layouts/rails_admin/pjax.html.haml
+++ b/app/views/layouts/rails_admin/pjax.html.haml
@@ -6,8 +6,8 @@
 .page-header
   %h1= @page_name
 - flash && flash.each do |key, value|
-  .alert{class: flash_alert_class(key)}
-    %a.close{href: '#', :'data-dismiss' => "alert"} &times;
+  .alert.alert-dismissible{class: flash_alert_class(key)}
+    %button.close{type: 'button', :'data-dismiss' => "alert"} &times;
     = value
 = breadcrumb
 %ul.nav.nav-tabs


### PR DESCRIPTION
Correct styling of the .close button (use a button element) depends on the .alert-dismissible class.